### PR TITLE
Fix reference error in hidePoweredBy code sample

### DIFF
--- a/docs/hide-powered-by/index.md
+++ b/docs/hide-powered-by/index.md
@@ -53,7 +53,7 @@ Or you can require the individual module:
 ```javascript
 var hidePoweredBy = require('hide-powered-by')
 
-app.use(helmet.hidePoweredBy())
+app.use(hidePoweredBy())
 ```
 
 You can also *lie* in this header to throw a hacker off the scent. For example, to make it look like your site is powered by PHP:


### PR DESCRIPTION
Remove the reference to `helmet` in the code sample demonstrating the `hide-powered-by` standalone module.