### PR TITLE
Use uuid module in CSP docs, using node-uuid is deprecated

### DIFF
--- a/docs/csp/index.md
+++ b/docs/csp/index.md
@@ -230,10 +230,10 @@ app.use(csp({
 You can dynamically generate nonces to allow inline `<script>` tags to be safely evaluated. Here's a simple example:
 
 ```js
-var uuid = require('node-uuid')
+var uuidv4 = require('uuid/v4')
 
 app.use(function (req, res, next) {
-  res.locals.nonce = uuid.v4()
+  res.locals.nonce = uuidv4()
   next()
 })
 


### PR DESCRIPTION
This adjusts the example for nonces, updating it to use the `uuid` module instead.