### PR TITLE
Change `crossdomain` to `permittedCrossDomainPolicies`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Visit each module's page to learn more.
 | Module | Included by default? |
 |---|---|
 | [contentSecurityPolicy](csp) for setting Content Security Policy |  |
-| [crossdomain](crossdomain) for handling Adobe products' crossdomain requests |  |
+| [permittedCrossDomainPolicies](crossdomain) for handling Adobe products' crossdomain requests |  |
 | [dnsPrefetchControl](dns-prefetch-control) controls browser DNS prefetching | ✓ |
 | [expectCt](expect-ct) for handling Certificate Transparency |  |
 | [featurePolicy](feature-policy) to limit your site's features | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,6 @@ Visit each module's page to learn more.
 | Module | Included by default? |
 |---|---|
 | [contentSecurityPolicy](csp) for setting Content Security Policy |  |
-| [permittedCrossDomainPolicies](crossdomain) for handling Adobe products' crossdomain requests |  |
 | [dnsPrefetchControl](dns-prefetch-control) controls browser DNS prefetching | ✓ |
 | [expectCt](expect-ct) for handling Certificate Transparency |  |
 | [featurePolicy](feature-policy) to limit your site's features | |
@@ -62,5 +61,6 @@ Visit each module's page to learn more.
 | [ieNoOpen](ienoopen) sets X-Download-Options for IE8+ | ✓ |
 | [noCache](nocache) to disable client-side caching |  |
 | [noSniff](dont-sniff-mimetype) to keep clients from sniffing the MIME type | ✓ |
+| [permittedCrossDomainPolicies](crossdomain) for handling Adobe products' crossdomain requests |  |
 | [referrerPolicy](referrer-policy) to hide the Referer header |  |
 | [xssFilter](xss-filter) adds some small XSS protections | ✓ |

--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ You can see more in [the documentation](/docs).
 | Module | Default? |
 |---|---|
 | [contentSecurityPolicy](/docs/csp/) for setting Content Security Policy |  |
-| [crossdomain](/docs/crossdomain/) for handling Adobe products' crossdomain requests |  |
+| [permittedCrossDomainPolicies](/docs/crossdomain/) for handling Adobe products' crossdomain requests |  |
 | [dnsPrefetchControl](/docs/dns-prefetch-control) controls browser DNS prefetching | ✓ |
 | [expectCt](/docs/expect-ct/) for handling Certificate Transparency |  |
 | [featurePolicy](/docs/feature-policy/) to limit your site's features |  |

--- a/index.md
+++ b/index.md
@@ -32,7 +32,6 @@ You can see more in [the documentation](/docs).
 | Module | Default? |
 |---|---|
 | [contentSecurityPolicy](/docs/csp/) for setting Content Security Policy |  |
-| [permittedCrossDomainPolicies](/docs/crossdomain/) for handling Adobe products' crossdomain requests |  |
 | [dnsPrefetchControl](/docs/dns-prefetch-control) controls browser DNS prefetching | ✓ |
 | [expectCt](/docs/expect-ct/) for handling Certificate Transparency |  |
 | [featurePolicy](/docs/feature-policy/) to limit your site's features |  |
@@ -42,5 +41,6 @@ You can see more in [the documentation](/docs).
 | [ieNoOpen](/docs/ienoopen) sets X-Download-Options for IE8+ | ✓ |
 | [noCache](/docs/nocache/) to disable client-side caching |  |
 | [noSniff](/docs/dont-sniff-mimetype) to keep clients from sniffing the MIME type | ✓ |
+| [permittedCrossDomainPolicies](/docs/crossdomain/) for handling Adobe products' crossdomain requests |  |
 | [referrerPolicy](/docs/referrer-policy) to hide the Referer header |  |
 | [xssFilter](/docs/xss-filter) adds some small XSS protections | ✓ |


### PR DESCRIPTION
When I was reading the docs I was trying
```
app.user(helmet({
 crossdomain: true
}))
```
only after reading the source code I found out that the module is called `permittedCrossDomainPolicies` inside helmet.