### PR TITLE
docs: fix incorrect HSTS max-age value in FAQ

### DIFF
--- a/content/faq/you-might-not-need-helmet.md
+++ b/content/faq/you-might-not-need-helmet.md
@@ -16,7 +16,7 @@ const HEADERS = {
   "Cross-Origin-Resource-Policy": "same-origin",
   "Origin-Agent-Cluster": "?1",
   "Referrer-Policy": "no-referrer",
-  "Strict-Transport-Security": "max-age=15552000; includeSubDomains",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
   "X-Content-Type-Options": "nosniff",
   "X-DNS-Prefetch-Control": "off",
   "X-Download-Options": "noopen",


### PR DESCRIPTION
The "You might not need Helmet" FAQ page had `max-age=15552000` (180 days) for the `Strict-Transport-Security` header, but Helmet's actual default is `max-age=31536000` (365 days).

This matches the value shown on the main reference page and in the [HSTS source code](https://github.com/helmetjs/helmet/blob/main/middlewares/strict-transport-security/index.ts#L3) (`365 * 24 * 60 * 60 = 31536000`).