### PR TITLE
docs: replace wiki redirect with direct FAQ link

### DIFF
--- a/content/faq/helmet-4-upgrade.md
+++ b/content/faq/helmet-4-upgrade.md
@@ -53,4 +53,4 @@ The CSP middleware used to do browser sniffing in an attempt to set the best CSP
 
 This means that a few options were removed: `browserSniff`, `disableAndroid`, and `setAllHeaders`.
 
-If you want to set legacy headers, see the guide ["Setting legacy Content Security Policy headers in Helmet 4"](https://github.com/helmetjs/helmet/wiki/Setting-legacy-Content-Security-Policy-headers-in-Helmet-4).
+If you want to set legacy headers, see ["How do I set legacy Content Security Policy headers?"]({{< ref "faq/legacy-csp-headers" >}}).


### PR DESCRIPTION
The Helmet 4 upgrade guide linked to a [GitHub wiki page](https://github.com/helmetjs/helmet/wiki/Setting-legacy-Content-Security-Policy-headers-in-Helmet-4) that just says "This page has moved" and redirects to the FAQ page on this site.

Replaced with a direct internal link to avoid the unnecessary redirect.