### PR TITLE
docs: use 32-byte nonce in conditional options example

### DIFF
--- a/content/faq/conditional-options.md
+++ b/content/faq/conditional-options.md
@@ -27,7 +27,7 @@ As a special case, the `Content-Security-Policy` header can be set conditionally
 
 ```javascript
 app.use((req, res, next) => {
-  res.locals.cspNonce = crypto.randomBytes(16).toString("hex");
+  res.locals.cspNonce = crypto.randomBytes(32).toString("hex");
   next();
 });
 


### PR DESCRIPTION
The CSP nonce example in `conditional-options.md` uses `crypto.randomBytes(16)` (128 bits), while all other nonce examples in the documentation use `crypto.randomBytes(32)` (256 bits):

- `csp-nonce-example.md` line 24: `crypto.randomBytes(32, ...)`
- `_index.md` line 87: `crypto.randomBytes(32).toString("hex")`
- helmet README line 85: `crypto.randomBytes(32).toString("hex")`

This updates the example to use 32 bytes for consistency across the documentation.