### PR TITLE
docs: replace wiki redirect with internal link for ALLOW-FROM

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -562,7 +562,7 @@ The legacy `X-Frame-Options` header to help you mitigate [clickjacking attacks](
 app.use(helmet());
 ```
 
-`action` is a string that specifies which directive to use—either `DENY` or `SAMEORIGIN`. (A legacy directive, `ALLOW-FROM`, is not supported by Helmet. [Read more here.](https://github.com/helmetjs/helmet/wiki/How-to-use-X%E2%80%93Frame%E2%80%93Options's-%60ALLOW%E2%80%93FROM%60-directive)) It defaults to `SAMEORIGIN`.
+`action` is a string that specifies which directive to use—either `DENY` or `SAMEORIGIN`. (A legacy directive, `ALLOW-FROM`, is not supported by Helmet. [Read more here.]({{< ref "faq/x-frame-options-allow-from-directive" >}})) It defaults to `SAMEORIGIN`.
 
 Examples:
 


### PR DESCRIPTION
The X-Frame-Options `ALLOW-FROM` link in `_index.md` points to the GitHub wiki page, which just redirects to the FAQ at `helmetjs.github.io/faq/x-frame-options-allow-from-directive/`.

This replaces the wiki URL with Hugo's `ref` shortcode to link directly to the FAQ page, similar to how the Helmet 4 upgrade guide links to other FAQ pages.