### PR TITLE
docs: update Origin-Agent-Cluster spec link to WHATWG

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -288,7 +288,7 @@ Default:
 Origin-Agent-Cluster: ?1
 ```
 
-The `Origin-Agent-Cluster` header provides a mechanism to allow web applications to isolate their origins from other processes. Read more about it [in the spec](https://whatpr.org/html/6214/origin.html#origin-keyed-agent-clusters).
+The `Origin-Agent-Cluster` header provides a mechanism to allow web applications to isolate their origins from other processes. Read more about it [in the spec](https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters).
 
 This header takes no options and is set by default.
 


### PR DESCRIPTION
The Origin-Agent-Cluster spec link points to `whatpr.org/html/6214/`, which hosts preview builds of WHATWG spec pull requests. Since the spec has been merged into the HTML Living Standard, the canonical URL is now on `html.spec.whatwg.org`.

Updated from:
`https://whatpr.org/html/6214/origin.html#origin-keyed-agent-clusters`

To:
`https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters`

(Same fix as helmetjs/helmet#526)